### PR TITLE
Android 10 (Q) does not call BluetoothGattCallback.onConnectionStateC…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
 fastlane/readme.md
+.idea/*
+**/.DS_Store

--- a/blessed/src/main/java/com/welie/blessed/BluetoothCentral.java
+++ b/blessed/src/main/java/com/welie/blessed/BluetoothCentral.java
@@ -41,7 +41,12 @@ import android.os.Handler;
 import android.os.ParcelUuid;
 
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import timber.log.Timber;

--- a/blessed/src/main/java/com/welie/blessed/BluetoothCentral.java
+++ b/blessed/src/main/java/com/welie/blessed/BluetoothCentral.java
@@ -321,6 +321,10 @@ public class BluetoothCentral {
          */
         @Override
         public void disconnected(final BluetoothPeripheral peripheral, final int status) {
+            if (context != null && connectedPeripherals.size() == 1 &&
+                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                context.unregisterReceiver(bluetoothStateReceiver);
+            }
             // Remove it from the connected peripherals map
             connectedPeripherals.remove(peripheral.getAddress());
 
@@ -329,10 +333,6 @@ public class BluetoothCentral {
                 unconnectedPeripherals.remove(peripheral.getAddress());
             }
 
-            if (context != null && connectedPeripherals.isEmpty() &&
-                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                context.unregisterReceiver(bluetoothStateReceiver);
-            }
             // Trigger callback
             callBackHandler.post(new Runnable() {
                 @Override

--- a/blessed/src/main/java/com/welie/blessed/BluetoothPeripheral.java
+++ b/blessed/src/main/java/com/welie/blessed/BluetoothPeripheral.java
@@ -39,6 +39,9 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.SystemClock;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -958,8 +961,8 @@ public class BluetoothPeripheral {
                 @Override
                 public void run() {
                     if (bluetoothGatt != null) {
-                        Timber.i("force disconnect '%s' (%s)", getName(), getAddress());
                         bluetoothGatt.disconnect();
+                        Timber.i("force disconnect '%s' (%s) %s", getName(), getAddress(), bluetoothGatt);
                     }
                 }
             });
@@ -994,6 +997,7 @@ public class BluetoothPeripheral {
      *
      * @return Address of the bluetooth peripheral
      */
+    @NotNull
     public String getAddress() {
         return device.getAddress();
     }
@@ -1012,6 +1016,7 @@ public class BluetoothPeripheral {
      *
      * @return name of the bluetooth peripheral
      */
+    @Nullable
     public String getName() {
         return device.getName();
     }


### PR DESCRIPTION
…hange when turning bluetooth OFF

On Android 10 (Q), the `BluetoothGattCallback.onConnectionStateChange` callback is never called as opposed to lower versions.

As a result, the currently connected peripheral is never removed from the `connectedPeripherals` map, thus `BluetoothCentral` is left in a faulty state.

Fixes #16 :
- register a `BroadcastReceiver` for bluetooth state (on first connect of a peripheral)
- unregister the `BrodcastReceiver` at last disconnect
- on bluetooth change state to OFF, cycle through all `connectedPeripherals` and call `cancelConnection` on each, the remove them from the state map.
- call `onDisconnectedPeripheral` for each of these `connectedPeripherals`