### PR TITLE
Add: Bluetooth Adapter Status Callback

### DIFF
--- a/blessed/src/main/java/com/welie/blessed/BluetoothCentral.java
+++ b/blessed/src/main/java/com/welie/blessed/BluetoothCentral.java
@@ -996,18 +996,22 @@ public class BluetoothCentral {
                             expectingBluetoothOffDisconnects = true;
                             startDisconnectionTimer();
                         }
+                        bluetoothCentralCallback.onBluetoothAdapterStateChanged(BluetoothAdapter.STATE_OFF);
                         Timber.d("bluetooth turned off");
                         break;
                     case BluetoothAdapter.STATE_TURNING_OFF:
                         expectingBluetoothOffDisconnects = true;
+                        bluetoothCentralCallback.onBluetoothAdapterStateChanged(BluetoothAdapter.STATE_TURNING_OFF);
                         Timber.d("bluetooth turning off");
                         break;
                     case BluetoothAdapter.STATE_ON:
                         expectingBluetoothOffDisconnects = false;
+                        bluetoothCentralCallback.onBluetoothAdapterStateChanged(BluetoothAdapter.STATE_ON);
                         Timber.d("bluetooth turned on");
                         break;
                     case BluetoothAdapter.STATE_TURNING_ON:
                         expectingBluetoothOffDisconnects = false;
+                        bluetoothCentralCallback.onBluetoothAdapterStateChanged(BluetoothAdapter.STATE_TURNING_ON);
                         Timber.d("bluetooth turning on");
                         break;
                 }

--- a/blessed/src/main/java/com/welie/blessed/BluetoothCentralCallback.java
+++ b/blessed/src/main/java/com/welie/blessed/BluetoothCentralCallback.java
@@ -71,5 +71,5 @@ public abstract class BluetoothCentralCallback {
      *
      * @param state the current status code for the adapter
      */
-    public abstract void onBluetoothAdapterStateChanged(final int state);
+    public void onBluetoothAdapterStateChanged(final int state) {};
 }

--- a/blessed/src/main/java/com/welie/blessed/BluetoothCentralCallback.java
+++ b/blessed/src/main/java/com/welie/blessed/BluetoothCentralCallback.java
@@ -66,4 +66,10 @@ public abstract class BluetoothCentralCallback {
      */
     public void onScanFailed(final int errorCode) {}
 
+    /**
+     * Bluetooth adapter status changed
+     *
+     * @param state the current status code for the adapter
+     */
+    public abstract void onBluetoothAdapterStateChanged(final int state);
 }


### PR DESCRIPTION
As commented in : https://github.com/weliem/blessed-android/issues/22
Add a callback to reuse the lib broadcast receiver to get the status of the BT adapter.