### PR TITLE
Added one line logger in onConnectionStateChange

### DIFF
--- a/blessed/src/main/java/com/welie/blessed/BluetoothPeripheral.java
+++ b/blessed/src/main/java/com/welie/blessed/BluetoothPeripheral.java
@@ -161,6 +161,8 @@ public class BluetoothPeripheral {
             final int previousState = state;
             state = newState;
 
+			Logger.i(TAG, "onConnectionStateChange for %s  previousState: '%s' newState:'%s' with status: '%s'", getAddress(), previousState, newState, status);
+
             final HciStatus hciStatus = HciStatus.fromValue(status);
             if (hciStatus == HciStatus.SUCCESS) {
                 switch (newState) {


### PR DESCRIPTION
I need this logger line in order to follow the pure changes on ConnectionState, since onConnectionStateChange function calls different sub functions in deep, I'm having problems keeping track of changes on ConnectionState.