### PR TITLE
Add Transport configuration for BluetoothPeripheral

### DIFF
--- a/blessed/src/main/java/com/welie/blessed/BluetoothCentralManager.java
+++ b/blessed/src/main/java/com/welie/blessed/BluetoothCentralManager.java
@@ -67,6 +67,7 @@ public class BluetoothCentralManager {
     private static final long SCAN_TIMEOUT = 180_000L;
     private static final int SCAN_RESTART_DELAY = 1000;
     private static final int MAX_CONNECTION_RETRIES = 1;
+    private static final Transport DEFAULT_TRANSPORT = Transport.LE;
 
     private static final String NO_PERIPHERAL_ADDRESS_PROVIDED = "no peripheral address provided";
     private static final String NO_VALID_PERIPHERAL_PROVIDED = "no valid peripheral provided";
@@ -96,6 +97,7 @@ public class BluetoothCentralManager {
     private boolean expectingBluetoothOffDisconnects = false;
     private @Nullable Runnable disconnectRunnable;
     private @NotNull final Map<String, String> pinCodes = new ConcurrentHashMap<>();
+    private @NotNull Transport transport = DEFAULT_TRANSPORT;
 
     //region Callbacks
 
@@ -369,6 +371,24 @@ public class BluetoothCentralManager {
         Objects.requireNonNull(scanMode);
 
         scanSettings = getScanSettings(scanMode);
+    }
+
+    /**
+     * Get the transport to be used during connection phase.
+     *
+     * @return transport
+     */
+    public Transport getTransport() {
+        return transport;
+    }
+
+    /**
+     * Set the transport to be used when creating instances of {@link BluetoothPeripheral}.
+     *
+     * @param transport the Transport to set
+     */
+    public void setTransport(@NotNull Transport transport) {
+        this.transport = transport;
     }
 
     private void startScan(@NotNull final List<ScanFilter> filters, @NotNull final ScanSettings scanSettings, @NotNull final ScanCallback scanCallback) {
@@ -731,7 +751,7 @@ public class BluetoothCentralManager {
         } else if (scannedPeripherals.containsKey(peripheralAddress)) {
             return Objects.requireNonNull(scannedPeripherals.get(peripheralAddress));
         } else {
-            final BluetoothPeripheral peripheral = new BluetoothPeripheral(context, bluetoothAdapter.getRemoteDevice(peripheralAddress), internalCallback, new BluetoothPeripheralCallback.NULL(), callBackHandler);
+            final BluetoothPeripheral peripheral = new BluetoothPeripheral(context, bluetoothAdapter.getRemoteDevice(peripheralAddress), internalCallback, new BluetoothPeripheralCallback.NULL(), callBackHandler, transport);
             scannedPeripherals.put(peripheralAddress, peripheral);
             return peripheral;
         }

--- a/blessed/src/main/java/com/welie/blessed/Transport.java
+++ b/blessed/src/main/java/com/welie/blessed/Transport.java
@@ -1,0 +1,41 @@
+package com.welie.blessed;
+
+import android.bluetooth.BluetoothDevice;
+
+import org.jetbrains.annotations.NotNull;
+
+
+/**
+ * This enum describes all possible values for transport.
+ */
+public enum Transport {
+    /**
+     * No preference of physical transport for GATT connections to remote dual-mode devices
+     */
+    AUTO(BluetoothDevice.TRANSPORT_AUTO),
+
+    /**
+     * Prefer BR/EDR transport for GATT connections to remote dual-mode devices is necessary.
+     */
+    BR_EDR(BluetoothDevice.TRANSPORT_BREDR),
+
+    /**
+     * Prefer LE transport for GATT connections to remote dual-mode devices
+     */
+    LE(BluetoothDevice.TRANSPORT_LE);
+
+    public final int value;
+
+    Transport(int value) {
+        this.value = value;
+    }
+
+    @NotNull
+    public static Transport fromValue(final int value) {
+        for (Transport transport : values()) {
+            if (transport.value == value)
+                return transport;
+        }
+        return AUTO;
+    }
+}

--- a/blessed/src/test/java/com/welie/blessed/BluetoothCentralManagerTest.java
+++ b/blessed/src/test/java/com/welie/blessed/BluetoothCentralManagerTest.java
@@ -1,7 +1,6 @@
 package com.welie.blessed;
 
 import android.Manifest;
-
 import android.app.Application;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
@@ -10,9 +9,12 @@ import android.bluetooth.le.ScanCallback;
 import android.bluetooth.le.ScanFilter;
 import android.bluetooth.le.ScanResult;
 import android.bluetooth.le.ScanSettings;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Handler;
+
+import androidx.test.core.app.ApplicationProvider;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -50,10 +52,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 import static org.robolectric.Shadows.shadowOf;
-
-import android.content.Context;
-
-import androidx.test.core.app.ApplicationProvider;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest=Config.NONE, sdk = { M }, shadows={ShadowBluetoothLEAdapter.class} )
@@ -911,5 +909,21 @@ public class BluetoothCentralManagerTest {
     public void When_permission_are_not_correct_then_a_scan_is_not_attempted() {
         central.scanForPeripherals();
         verify(scanner, never()).startScan(ArgumentMatchers.<ScanFilter>anyList(), any(ScanSettings.class), any(ScanCallback.class));
+    }
+
+    @Test
+    public void Given_a_transport_when_getPeripheral_is_called_a_peripheral_is_returned_with_specified_transport() {
+        // Given
+        String address = "AC:DE:EF:12:34:56";
+        BluetoothDevice device = mock(BluetoothDevice.class);
+        when(device.getAddress()).thenReturn(address);
+        bluetoothAdapter.addDevice(device);
+
+        central.setTransport(Transport.BR_EDR);
+
+        // Get peripheral and supply lowercase mac address
+        BluetoothPeripheral peripheral = central.getPeripheral(address);
+        assertNotNull(peripheral);
+        assertEquals(Transport.BR_EDR, peripheral.getTransport());
     }
 }

--- a/blessed/src/test/java/com/welie/blessed/BluetoothPeripheralTest.java
+++ b/blessed/src/test/java/com/welie/blessed/BluetoothPeripheralTest.java
@@ -54,6 +54,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
@@ -102,6 +103,8 @@ public class BluetoothPeripheralTest {
     @Captor
     ArgumentCaptor<GattStatus> captorGattStatus;
 
+    private final Transport transport = Transport.LE;
+
     @Before
     public void setUp() {
         openMocks(this);
@@ -110,7 +113,7 @@ public class BluetoothPeripheralTest {
         when(device.connectGatt(any(Context.class), anyBoolean(), any(BluetoothGattCallback.class), anyInt())).thenReturn(gatt);
         when(gatt.getDevice()).thenReturn(device);
 
-        peripheral = new BluetoothPeripheral(context, device, internalCallback, peripheralCallback, handler);
+        peripheral = new BluetoothPeripheral(context, device, internalCallback, peripheralCallback, handler, transport);
     }
 
     @Test
@@ -122,7 +125,7 @@ public class BluetoothPeripheralTest {
         assertEquals(CONNECTING,  peripheral.getState());
 
         ArgumentCaptor<BluetoothGattCallback> captor = ArgumentCaptor.forClass(BluetoothGattCallback.class);
-        verify(device).connectGatt(any(Context.class), anyBoolean(), captor.capture(), anyInt());
+        verify(device).connectGatt(any(Context.class), anyBoolean(), captor.capture(), eq(transport.value));
         BluetoothGattCallback callback = captor.getValue();
         callback.onConnectionStateChange(gatt, GATT_SUCCESS, STATE_CONNECTED);
 


### PR DESCRIPTION
- The ability to configure transport is essential when using dual-mode.
- Following the Convention over Configuration paradigm, therefore Transport_LE is used as default value and exposing configuration via BluetoothCentralManager.setTransport(Transport).


Solves #105 


<sub>Legal Imprint (Mandatory for legal reasons, sorry for that)</sub>
<sub>Cedulio Silva <cedulio.silva@daimler.com>, MBition GmbH, [imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sub>