### PR TITLE
#168 - Notify Failure

### DIFF
--- a/blessed/src/main/java/com/welie/blessed/BluetoothPeripheralManager.java
+++ b/blessed/src/main/java/com/welie/blessed/BluetoothPeripheralManager.java
@@ -599,11 +599,10 @@ public class BluetoothPeripheralManager {
         if (doesNotSupportNotifying(characteristic)) return false;
 
         boolean result = true;
-        for (BluetoothCentral device : getConnectedCentrals()) {
-            if (!notifyCharacteristicChanged(value, device, characteristic)) {
-                result = false;
-            }
+        for (final BluetoothCentral central : getCentralsWantingNotifications(characteristic)) {
+            result = result && notifyCharacteristicChanged(value, central, characteristic);
         }
+
         return result;
     }
 


### PR DESCRIPTION
This address the issue with notifications not working when attempting to notify all connected centrals that want to be notified. #168 